### PR TITLE
Improved layering - quos and vars

### DIFF
--- a/R/tfmt_layer.R
+++ b/R/tfmt_layer.R
@@ -57,6 +57,35 @@ layer_tfmt_arg.default<- function(x, y, arg_name, ...){
   }
 }
 
+## if group is an empty vars, keep the original value
+layer_tfmt_arg.group<- function(x, y, arg_name, ...){
+  x_arg_val <- x[[arg_name]]
+  y_arg_val <- y[[arg_name]]
+
+  if(identical(y_arg_val, vars())){
+    x_arg_val
+  }else{
+    y_arg_val
+  }
+}
+
+## if label/param/values/column is an empty quo, keep the original value
+layer_tfmt_arg.label<- function(x, y, arg_name, ...){
+  x_arg_val <- x[[arg_name]]
+  y_arg_val <- y[[arg_name]]
+
+  if(identical(y_arg_val, quo())){
+    x_arg_val
+  }else{
+    y_arg_val
+  }
+}
+
+layer_tfmt_arg.param <- layer_tfmt_arg.label
+layer_tfmt_arg.values <- layer_tfmt_arg.label
+layer_tfmt_arg.column <- layer_tfmt_arg.label
+
+
 layer_tfmt_arg.body_style <- function(x, y, ...,  join_body_styles = TRUE){
   x_body_style <- x[["body_style"]][["all_fmts"]]
   y_body_style <- y[["body_style"]][["all_fmts"]]

--- a/tests/testthat/test-tfmt.R
+++ b/tests/testthat/test-tfmt.R
@@ -149,8 +149,6 @@ test_that("basic tfmt - bare/char mix error", {
 
 })
 
-
-
 test_that("layering tfmt - default table elements - func/tfmt",{
 
   t_fmt_title <- tfmt(
@@ -321,4 +319,50 @@ test_that("layering tfmt - body style elements - join_body_style FALSE",{
 
 })
 
+test_that("layering tfmt - keeping original var/quo",{
 
+  t_fmt_o <- tfmt(
+    title = "Table Title",
+    group = c(Group1, Group2),
+    label = label1
+  )
+
+  t_fmt_layered <- t_fmt_o %>%
+    layer_tfmt(
+      tfmt(
+        title = "Table Title 2",
+        subtitle = "Table Subtitle"
+      ))
+
+  expect_s3_class( t_fmt_layered,"tfmt"  )
+  expect_equal( t_fmt_layered$title, "Table Title 2")
+  expect_equal( t_fmt_layered$subtitle, "Table Subtitle")
+  expect_equal( t_fmt_layered$group, vars(Group1, Group2), ignore_attr = TRUE )
+  expect_equal( t_fmt_layered$label, quo(label1), ignore_attr = TRUE )
+
+})
+
+test_that("layering tfmt - Mixing var/quo",{
+
+  t_fmt_o <- tfmt(
+    title = "Table Title",
+    group = c(Group1, Group2),
+    label = label1
+  )
+
+  t_fmt_layered <- t_fmt_o %>%
+    layer_tfmt(
+      tfmt(
+        title = "Table Title 2",
+        subtitle = "Table Subtitle",
+        label = label3
+
+      ))
+
+  expect_s3_class( t_fmt_layered,"tfmt"  )
+  expect_equal( t_fmt_layered$title, "Table Title 2")
+  expect_equal( t_fmt_layered$subtitle, "Table Subtitle")
+  expect_equal( t_fmt_layered$group, vars(Group1, Group2), ignore_attr = TRUE )
+  expect_equal( t_fmt_layered$label, quo(label3), ignore_attr = TRUE )
+
+})


### PR DESCRIPTION
Update layering to prevent a tfrmt from selecting an empty quo/vars over a populated one.