### PR TITLE
More select_col_plan edits

### DIFF
--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -4,6 +4,30 @@
 #' span_structures, define the spanned column names, and the label to apply.
 #' span_structures can be nested to allow for layered spanning headers.
 #'
+#' @details
+#'
+#' ## Column Selection
+#'
+#' When col_plan gets applied and is used to create the output table, the
+#' underlying logic becomes the input to \code{\link[dplyr]{select}}. Therefore,
+#' behavior falls to the \code{\link[dplyr]{select}} for sub-setting columns, renaming,
+#' and reordering the columns.
+#'
+#' Avoid beginning the \code{col_plan()} column selection with a deselection (ie
+#' \code{col_plan(-col1)}, \code{col_plan(-starts_with("value")))}. This will
+#' result in the table preserving all columns not "de-selected" in the
+#' statement, and the order of the columns not changed. It is preferred when
+#' creating the \code{col_plan()} to identify all the columns planned on
+#' preserving in the order they are wished to appear, or if
+#' <[`tidy-select`][dplyr_tidy_select]> arguments - such as
+#' \code{\link[dplyr]{everything}}- are used, identify the de-selection after
+#' the positive-selection. Experiment with the \code{\link[dplyr]{select}}
+#' function to understand this sort of behavior better.
+#'
+#' Alternatively, once the gt table is produced, use the \code{\link[gt]{cols_hide}}
+#' function to remove un-wanted columns.
+#'
+#'
 #' @rdname col_plan
 #'
 #' @param ... For a col_plan and span_structure,

--- a/man/col_plan.Rd
+++ b/man/col_plan.Rd
@@ -23,6 +23,29 @@ Using <\code{\link[=dplyr_tidy_select]{tidy-select}}> expressions and a series
 span_structures, define the spanned column names, and the label to apply.
 span_structures can be nested to allow for layered spanning headers.
 }
+\details{
+\subsection{Column Selection}{
+
+When col_plan gets applied and is used to create the output table, the
+underlying logic becomes the input to \code{\link[dplyr]{select}}. Therefore,
+behavior falls to the \code{\link[dplyr]{select}} for sub-setting columns, renaming,
+and reordering the columns.
+
+Avoid beginning the \code{col_plan()} column selection with a deselection (ie
+\code{col_plan(-col1)}, \code{col_plan(-starts_with("value")))}. This will
+result in the table preserving all columns not "de-selected" in the
+statement, and the order of the columns not changed. It is preferred when
+creating the \code{col_plan()} to identify all the columns planned on
+preserving in the order they are wished to appear, or if
+<\code{\link[=dplyr_tidy_select]{tidy-select}}> arguments - such as
+\code{\link[dplyr]{everything}}- are used, identify the de-selection after
+the positive-selection. Experiment with the \code{\link[dplyr]{select}}
+function to understand this sort of behavior better.
+
+Alternatively, once the gt table is produced, use the \code{\link[gt]{cols_hide}}
+function to remove un-wanted columns.
+}
+}
 \examples{
 library(dplyr)
 


### PR DESCRIPTION
resolves #131 

Change where new_name_quo gets created, and clean up so NA's cannot be put in for new name outputs

also a change to value processing in col_plan where empty values now get removed (ie trailing commas):
 - `col_plan( col1, col2, col3, )`
 - `col_plan( col1, span_structure("my label", col2, col3, ))` 
